### PR TITLE
fix: typo, add test

### DIFF
--- a/annotationspace.go
+++ b/annotationspace.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-type annotation int
+type Annotation int
 
 const (
 	colon      = ":"
@@ -17,24 +17,31 @@ const (
 )
 
 const (
-	TODO annotation = iota
+	TODO Annotation = iota
 	FIXME
 	NOTE
-	REFUCTOR
+	REFACTOR
 )
 
-func (a annotation) String() string {
+const (
+	todo     = "TODO"
+	fixme    = "FIXME"
+	note     = "NOTE"
+	refactor = "REFACTOR"
+)
+
+func (a Annotation) String() string {
 	switch a {
 	case TODO:
-		return "TODO"
+		return todo
 	case FIXME:
-		return "FIXME"
+		return fixme
 	case NOTE:
-		return "NOTE"
-	case REFUCTOR:
-		return "REFUCTOR"
+		return note
+	case REFACTOR:
+		return refactor
 	default:
-		panic("not decleare")
+		panic("not declare")
 	}
 }
 
@@ -70,8 +77,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 							pass.Reportf(c.Pos(), "require whitespace after FIXME:")
 						case strings.Contains(c.Text(), NOTE.String()+colon) && !strings.Contains(c.Text(), NOTE.String()+colon+whitespace):
 							pass.Reportf(c.Pos(), "require whitespace after NOTE:")
-						case strings.Contains(c.Text(), REFUCTOR.String()+colon) && !strings.Contains(c.Text(), REFUCTOR.String()+colon+whitespace):
-							pass.Reportf(c.Pos(), "require whitespace after REFUCTOR:")
+						case strings.Contains(c.Text(), REFACTOR.String()+colon) && !strings.Contains(c.Text(), REFACTOR.String()+colon+whitespace):
+							pass.Reportf(c.Pos(), "require whitespace after REFACTOR:")
 						}
 						// check colon
 						switch {
@@ -81,8 +88,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 							pass.Reportf(c.Pos(), "require colon after FIXME")
 						case strings.Contains(c.Text(), NOTE.String()) && !strings.Contains(c.Text(), NOTE.String()+colon):
 							pass.Reportf(c.Pos(), "require colon after NOTE")
-						case strings.Contains(c.Text(), REFUCTOR.String()) && !strings.Contains(c.Text(), REFUCTOR.String()+colon):
-							pass.Reportf(c.Pos(), "require colon after REFUCTOR")
+						case strings.Contains(c.Text(), REFACTOR.String()) && !strings.Contains(c.Text(), REFACTOR.String()+colon):
+							pass.Reportf(c.Pos(), "require colon after REFACTOR")
 						}
 					}
 				}

--- a/annotationspace_test.go
+++ b/annotationspace_test.go
@@ -11,3 +11,39 @@ func Test(t *testing.T) {
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, annotationspace.Analyzer, "a")
 }
+
+func Test_annotation_String(t *testing.T) {
+	tests := []struct {
+		name string
+		a    annotationspace.Annotation
+		want string
+	}{
+		{
+			"TODO",
+			annotationspace.TODO,
+			"TODO",
+		},
+		{
+			"FIXME",
+			annotationspace.FIXME,
+			"FIXME",
+		},
+		{
+			"NOTE",
+			annotationspace.NOTE,
+			"NOTE",
+		},
+		{
+			"REFACTOR",
+			annotationspace.REFACTOR,
+			"REFACTOR",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.a.String(); got != tt.want {
+				t.Errorf("annotation.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -7,7 +7,7 @@ func main() {
 	println("test")
 	// NOTE: NOTE
 	println("test")
-	// REFUCTOR: REFUCTOR
+	// REFACTOR: REFACTOR
 	println("test")
 	// TODO:TODO
 	println("test")
@@ -15,7 +15,7 @@ func main() {
 	println("test")
 	// NOTE:NOTE
 	println("test")
-	// REFUCTOR:REFUCTOR
+	// REFACTOR:REFACTOR
 	println("test")
 	// TODO
 	println("test")
@@ -23,6 +23,6 @@ func main() {
 	println("test")
 	// NOTE
 	println("test")
-	// REFUCTOR
+	// REFACTOR
 	println("test")
 }


### PR DESCRIPTION
Maybe `REFUCTOR` and `decleare` are not spelled correctly.
There is a partially globalized type declaration to add tests. I don't see any problem with this, as I think it will be needed for future use from inside the library.